### PR TITLE
Suggestion - Share Google Slide Control userscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ There's no focused plugins to get Userscripts running on Internet Explorer, but 
 * [Google Images direct link](https://greasyfork.org/scripts/3187-google-images-direct-link) - Adds direct links to images and pages in google image search.
 * [Google Translate Keyboard Shortcut](https://github.com/Greenek/google-translate-keyboard-shortcut-userscript) - Adds keyboard shortcut for quick swapping between active languages.
 * [Reddit Search On Google](https://github.com/marioortizmanero/reddit-search-on-google) - Adds a button to your Google searches to show only Reddit posts.
+* [Share Google Slides Control](https://github.com/LostInBrittany/share-google-slides-control) - Remotely share the control of a Google Slides presentation,
 
 
 ### Media


### PR DESCRIPTION
Share Google Slide Control is a tool to enable remote shared control of Google Slides presentations.

Shared Google Slides Control addresses a common pain point in remote presentations with multiple speakers: the challenge of slide deck control. Traditionally, only one speaker can manage the slide transitions, which can disrupt the flow of the presentation.

This project empowers presenters by allowing them to share control of a Google Slides deck with other speakers seamlessly.

The solution involves a Greasemonkey userscript on the presenter's side that connects to a remote server via WebSocket. This setup facilitates the following features:

- QR Code and Link Generation: The userscript generates a QR code or a link that can be shared with co-presenters.
- Remote Control Interface: Co-presenters can use the provided link to access a user interface that allows them to control the slide deck in real-time.

The project is fully open-source, with MIT Licence 