### PR TITLE
Added "YouTube Play All" to the YouTube section

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,8 @@ There's no focused plugins to get Userscripts running on Internet Explorer, but 
 * [Iridium](https://greasyfork.org/scripts/37902-iridium) - Adds a lot of extra functionality to YouTube, including pop-out videos, extra control over video/comment feeds, and much more.
 * [YouTube Classic](https://ytclassic.com/greasemonkey) - Reverts YouTube to its classic design (unround corners, restore dislikes + remove/redirect Shorts).
 * [YouTube Commenter Names](https://gist.github.com/lumynou5/74bcbab54cd9d8fcd3c873fffbac5d3d) - Make YouTube display the names of commenters instead of their handles.
-* [YouTube Peek Preview](https://greasyfork.org/en/scripts/370755-youtube-peek-preview) - See video thumbnails, ratings and other details when you mouse over a Youtube link from almost any website.
+* [YouTube Peek Preview](https://greasyfork.org/en/scripts/370755-youtube-peek-preview) - See video thumbnails, ratings and other details when you mouse over a YouTube link from almost any website.
+* [YouTube Play All](https://github.com/RobertWesner/YouTube-Play-All) - Returns the classic "Play All" button for not just videos, but also shorts and livestreams.
 
 
 ## Tutorials


### PR DESCRIPTION
Here is a userscript I have created a year ago and since actively maintained and improved upon. It adds the "Play All" button back to where it should have always been.

Originally it was not only created to fill the gap on non-chromium browsers as I could only find extensions for Chrome and its ilk, but also return it in a more authentic form, placing the button where it was last seen, instead of "just sticking it in the channel view" ^^

![image](https://github.com/user-attachments/assets/afad4f07-93b3-496b-9cdf-cab6faf36dc3)

Nowadays it supports playing all **shorts** and live **streams** while also allowing sorting by **popular**, none of which to my knowledge other extensions do. Random play is a custom shuffle that was added a couple of months ago, it allows shuffling with bias towards newest or oldest.

Currently the project sits at 40 stars with an estimated few hundreds to thousand users, based on downloads, if any of those metrics are relevant. 

I hope it is a nice addition to the list.
Thank you for maintaining this awesome repo :)