### PR TITLE
Add Classic Google Tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1011,6 +1011,23 @@ Userscripts can be used w/ the following browsers:
 
 ### <picture><source type="image/png" media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/google/white/icon32.png"><img height=20 src="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/google/icon32.png"></picture> Google
 
+<details> <!-- Classic Google Tabs -->
+    <summary><a href="https://github.com/Kirlovon/classic-google-tabs">Classic Google Tabs</a> - Brings back the "Maps" tab and removes the "AI Mode" tab in Google Search.</summary><br>
+    <blockquote>
+        <a href="https://github.com/Kirlovon/classic-google-tabs">
+            <img src="https://github.com/Kirlovon/classic-google-tabs/raw/main/assets/poster.webp"></a>
+        <p>This is a simple Userscript that reworks Google Search navigation tabs by removing the "AI Mode" tab, restoring the "Maps" tab, and optionally removing the "Short videos" tab.</p>
+    </blockquote>
+    <blockquote>
+        💾 <a href="https://github.com/Kirlovon/classic-google-tabs/raw/refs/heads/main/classic-google-tabs.user.js">
+            Install</a> /
+        📖 <a href="https://github.com/Kirlovon/classic-google-tabs/blob/main/README.md">
+            Readme</a> /
+        🐛 <a href="https://github.com/Kirlovon/classic-google-tabs/issues">
+            Report bug</a>
+    </blockquote>
+</details>
+
 <details> <!-- Don't track me Google -->
     <summary><a href="https://github.com/Rob--W/dont-track-me-google">Don't track me Google</a> - Removes link conversion in Google Search/Maps links.</summary><br>
     <blockquote>


### PR DESCRIPTION
With this PR, I'm adding [Classic Google Tabs](https://github.com/Kirlovon/classic-google-tabs). This userscript modifies Google Search navigation by removing the "AI Mode" tab and restoring the "Maps" tab.