### PR TITLE
Add Disable YouTube Hotkeys userscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -1534,6 +1534,21 @@ Userscripts can be used w/ the following browsers:
 
 ### <picture><source type="image/png" media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/white/icon32.png"><img height=17 src="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/icon32.png"></picture> YouTube
 
+<details> <!-- Disable YouTube Hotkeys with Modern Settings Page -->
+    <summary><a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">Disable YouTube Hotkeys</a> - with Modern Settings Page</summary><br>
+    <blockquote>
+        <p>Disable various YouTube hotkeys with fine-grained control (Excludes Search/Comments)</p>
+    </blockquote>
+    <blockquote>
+        💾 <a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">
+            Install</a> /
+        📢 <a href="https://yt-hotkeys.vkrishna04.me/">
+            View</a> /
+        🐛 <a href="https://github.com/Life-Experimentalist/Youtube-Keystrokes-Blocker/">
+            Report bug</a>
+    </blockquote>
+</details>
+
 <details> <!-- Simple Sponsor Skipper -->
     <summary><a href="https://greasyfork.org/scripts/453320-simple-sponsor-skipper">Simple Sponsor Skipper</a> - Skips annoying intros, sponsors & filler using the SponsorBlock API. Compatible w/ YouTube, Invidious, CloudTube & Odysee.</summary><br>
     <blockquote>

--- a/README.md
+++ b/README.md
@@ -1560,7 +1560,7 @@ Userscripts can be used w/ the following browsers:
 ### <picture><source type="image/png" media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/white/icon32.png"><img height=17 src="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/icon32.png"></picture> YouTube
 
 <details> <!-- Disable YouTube Hotkeys with Modern Settings Page -->
-    <summary><a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">Disable YouTube Hotkeys with Modern Settings Page</a> - Blocks selected YouTube hotkeys with fine-grained controls.</summary><br>
+    <summary><a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">Disable YouTube Hotkeys with Modern Settings Page</a> - Blocks selected YouTube hotkeys with fine-grained control.</summary><br>
     <blockquote>
         <p>Blocking pauses while typing in search, comments, chat, and other text fields.</p>
     </blockquote>

--- a/README.md
+++ b/README.md
@@ -1557,6 +1557,21 @@ Userscripts can be used w/ the following browsers:
 
 ### <picture><source type="image/png" media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/white/icon32.png"><img height=17 src="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/icon32.png"></picture> YouTube
 
+<details> <!-- Disable YouTube Hotkeys with Modern Settings Page -->
+    <summary><a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">Disable YouTube Hotkeys</a> - with Modern Settings Page</summary><br>
+    <blockquote>
+        <p>Disable various YouTube hotkeys with fine-grained control (Excludes Search/Comments)</p>
+    </blockquote>
+    <blockquote>
+        💾 <a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">
+            Install</a> /
+        📢 <a href="https://yt-hotkeys.vkrishna04.me/">
+            View</a> /
+        🐛 <a href="https://github.com/Life-Experimentalist/Youtube-Keystrokes-Blocker/">
+            Report bug</a>
+    </blockquote>
+</details>
+
 <details> <!-- Simple Sponsor Skipper -->
     <summary><a href="https://greasyfork.org/scripts/453320-simple-sponsor-skipper">Simple Sponsor Skipper</a> - Skips annoying intros, sponsors & filler using the SponsorBlock API. Compatible w/ YouTube, Invidious, CloudTube & Odysee.</summary><br>
     <blockquote>

--- a/README.md
+++ b/README.md
@@ -1558,16 +1558,16 @@ Userscripts can be used w/ the following browsers:
 ### <picture><source type="image/png" media="(prefers-color-scheme: dark)" srcset="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/white/icon32.png"><img height=17 src="https://cdn.jsdelivr.net/gh/awesome-scripts/awesome-userscripts@f11c95f/assets/images/icons/sites/youtube/icon32.png"></picture> YouTube
 
 <details> <!-- Disable YouTube Hotkeys with Modern Settings Page -->
-    <summary><a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">Disable YouTube Hotkeys</a> - with Modern Settings Page</summary><br>
+    <summary><a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">Disable YouTube Hotkeys with Modern Settings Page</a> - Blocks selected YouTube hotkeys with fine-grained controls.</summary><br>
     <blockquote>
-        <p>Disable various YouTube hotkeys with fine-grained control (Excludes Search/Comments)</p>
+        <p>Blocking pauses while typing in search, comments, chat, and other text fields.</p>
     </blockquote>
     <blockquote>
-        💾 <a href="https://greasyfork.org/en/scripts/563265-disable-youtube-hotkeys-with-modern-settings-page">
+        💾 <a href="https://update.greasyfork.org/scripts/563265/Disable%20YouTube%20Hotkeys%20with%20Modern%20Settings%20Page.user.js">
             Install</a> /
-        📢 <a href="https://yt-hotkeys.vkrishna04.me/">
-            View</a> /
-        🐛 <a href="https://github.com/Life-Experimentalist/Youtube-Keystrokes-Blocker/">
+        📖 <a href="https://github.com/Life-Experimentalist/Youtube-Keystrokes-Blocker#readme">
+            Readme</a> /
+        🐛 <a href="https://github.com/Life-Experimentalist/Youtube-Keystrokes-Blocker/issues">
             Report bug</a>
     </blockquote>
 </details>


### PR DESCRIPTION
## Summary

Add Disable YouTube Hotkeys with Modern Settings Page to the YouTube userscript list.

## Changes

- Use the full script title and a functional description
- Link Install directly to the current Greasy Fork userscript
- Apply established Readme and Report bug link conventions
- Clarify that blocking pauses while typing in text fields

## Testing

- Downloaded userscript v5.0.1 and ran `node --check`
- `npm ci --ignore-scripts`
- `npm run lint`
- `npm audit --audit-level=high`: 0 vulnerabilities
- Lychee: 705 links checked, 609 OK, 0 errors
- GitHub Markdown rendering and balanced `<details>` tags

## Did this cause any problems?

README-only change. Revert the added entry to restore the previous list.
