### PR TITLE
Add Violentmonkey to Chromium compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ Userscripts can be used w/ the following browsers:
                 <a href="https://chromewebstore.google.com/detail/tampermonkey/dhdgffkkebhmkfjojejmpbldmpobfkfo"
                    title="Install Tampermonkey for Chrome">
                         Tampermonkey</a><sup>1</sup>
+                <a href="https://chromewebstore.google.com/detail/violentmonkey/jinjaccalgkegednnccohejagnlnfdag"
+                   title="Install Violentmonkey for Chrome">
+                        <img width=16 src="https://cdn.staticdelivr.com/gl/adamlui/userscripts/9cbcecc/assets/images/icons/userscript-managers/violentmonkey/icon25.png"></a>
+                <a href="https://chromewebstore.google.com/detail/violentmonkey/jinjaccalgkegednnccohejagnlnfdag"
+                   title="Install Violentmonkey for Chrome">
+                        Violentmonkey</a><sup>2</sup>
                 <a href="https://chromewebstore.google.com/detail/scriptcat/ndcooeababalnlpkfedmmbbbgkljhpjf"
                    title="Install ScriptCat for Chrome">
                         <img width=16 src="https://cdn.staticdelivr.com/gl/adamlui/userscripts/9cbcecc/assets/images/icons/userscript-managers/scriptcat/icon16.png"></a>


### PR DESCRIPTION
## Summary

Restore Violentmonkey to Chromium userscript manager compatibility now that its Chrome Web Store release uses Manifest V3.

Closes #150.

## Changes

- Add current Violentmonkey Chrome Web Store listing.
- Reuse existing manager icon and compatibility footnote.

## Testing

- `npm run lint`
- Lychee check against added Chrome Web Store URL: 0 errors
- Repository-wide Lychee currently fails only on pre-existing migrated-script links fixed by #155

## Did this cause any problems?

Revert commit `79ab1bf`.