### PR TITLE
Fix Amazon screenshot and schedule link checks

### DIFF
--- a/.github/workflows/validate-links-on-push-pr.yml
+++ b/.github/workflows/validate-links-on-push-pr.yml
@@ -1,4 +1,4 @@
-name: Validate links on push + PR
+name: Validate links
 
 on:
   push:
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ Userscripts can be used w/ the following browsers:
     <summary><a href="https://github.com/jhyland87/userscript-amazon-wishlist-search/#readme">Amazon Wishlist Search</a> - Adds a search input field to the wishlist dropdown (supports regex search).</summary><br>
     <blockquote>
         <a href="https://github.com/jhyland87/userscript-amazon-wishlist-search/#readme">
-            <img width=511 src="https://raw.githubusercontent.com/jhyland87/userscript-amazon-wishlist-search/refs/heads/main/assets/amazon-wishlist-search-demo-480.gif"></a>
+            <img width=511 src="https://raw.githubusercontent.com/jhyland87/userscript-amazon-wishlist-search/615848b1f5977ce9245b4aea797e9bcfb9aaddc7/assets/amazon-wishlist-search-demo-480.Aug-25-2026.gif"></a>
     </blockquote>
     <blockquote>
         💾 <a href="https://github.com/jhyland87/userscript-amazon-wishlist-search/releases/latest/download/amazon-wishlist-search.user.js">


### PR DESCRIPTION
## Summary

Restore the Amazon Wishlist Search screenshot and make link validation catch future external rot without waiting for a contributor pull request.

## Changes

- Pin the current screenshot asset to an immutable source commit
- Run link validation weekly on Monday at 06:17 UTC
- Allow maintainers to start link validation manually

## Testing

- `npm ci --ignore-scripts`
- `npm run lint`
- `npm audit --audit-level=high`: 0 vulnerabilities
- Lychee: 708 links checked, 612 OK, 0 errors
- `git diff --check`

## Did this cause any problems?

README and workflow-only change. Revert this commit to restore the previous screenshot URL and workflow triggers.